### PR TITLE
Exit with code 78 (neutral) rather than failure when the file is not modified

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -23,5 +23,5 @@ if push_event.modified?(file_path)
   exit(0)
 else
   puts "#{file_path} was not modified"
-  exit(1)
+  exit(78)
 end


### PR DESCRIPTION
This GH Action feature was maybe added after this code was written, but there is now support for exiting with "neutral" status: https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses

I think this makes sense since if the subject file is unmodified, this check fails (and, depending on your repo config, may prevent merging) - but that's not a failure, per se, it's just that we don't want to take the subsequent "yes it was modified" action.