### PR TITLE
Use neutral exit status

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -23,5 +23,5 @@ if push_event.modified?(file_path)
   exit(0)
 else
   puts "#{file_path} was not modified"
-  exit(1)
+  exit(78)
 end


### PR DESCRIPTION
Hi @nholden ,

I think exiting with the neutral status fits better with the filter. This way the check won't show it as a failure when the path is not modified.

https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses